### PR TITLE
Exclude Notifications from the tests to prevent crash

### DIFF
--- a/Sources/RobotKit/Actions/Notification.swift
+++ b/Sources/RobotKit/Actions/Notification.swift
@@ -5,6 +5,7 @@
 //  Created by Ahmed Shendy on 29/08/2022.
 //
 
+#if RELEASE
 import Foundation
 import UserNotifications
 
@@ -69,3 +70,4 @@ public actor RobotNotification: SelfTasking {
         return await current.notificationSettings().authorizationStatus
     }
 }
+#endif

--- a/Sources/RobotKit/Robot.swift
+++ b/Sources/RobotKit/Robot.swift
@@ -35,8 +35,10 @@ public actor Robot: SelfTasking {
     /// Robot information using [Vision](https://developer.apple.com/documentation/vision)
     public let vision = RobotVision()
     
+    #if RELEASE
     /// Robot control of notification center
     public let notification = RobotNotification()
+    #endif
     
     /// Robot information of the NSApplication
     @MainActor


### PR DESCRIPTION
`UNUserNotificationCenter.current()` crashes when running the tests. We can't create a mock `UNUserNotificationCenter` so we need to exclude it from the tests.